### PR TITLE
Update InternetManager.kt

### DIFF
--- a/src/main/kotlin/atm/bloodworkxgaming/serverstarter/InternetManager.kt
+++ b/src/main/kotlin/atm/bloodworkxgaming/serverstarter/InternetManager.kt
@@ -22,7 +22,7 @@ class InternetManager(private val configFile: ConfigFile) {
     fun checkConnection(): Boolean {
         var reached = 0
 
-        val urls = listOf("http://example.com", "http://google.com")
+        val urls = listOf("http://microsoft.com", "http://google.com")
         for (url in urls) {
             try {
                 LOGGER.info("Testing $url.")


### PR DESCRIPTION
example.com couldn't be pinged from my machine by any means, retried reboot, router restart, and firewall exceptions but to no vail. I am able to ping any other website BUT example.com which stops the server from booting up stating that I do not have an internet connection while I HAVE an internet connection.